### PR TITLE
typo fix: UplinkEcData -> UplinkIcData

### DIFF
--- a/firmware/python/atlas_rd53_atca_dev/_AtlasRd53EmuLpGbtLaneReg.py
+++ b/firmware/python/atlas_rd53_atca_dev/_AtlasRd53EmuLpGbtLaneReg.py
@@ -195,7 +195,7 @@ class AtlasRd53EmuLpGbtLaneReg(pr.Device):
         ))
 
         self.add(pr.RemoteVariable(
-            name         = 'UplinkEcData',
+            name         = 'UplinkIcData',
             offset       = 0x854,
             bitSize      = 2,
             mode         = 'RW',


### PR DESCRIPTION
@ruck314 

typo fix: UplinkEcData -> UplinkIcData

VHDL code:
https://github.com/slaclab/atlas-rd53-atca-dev/blob/master/firmware/common/rtl/AtlasRd53EmuLpGbtLaneReg.vhd#L227