### PR TITLE
disable the App channel 24-127 by default

### DIFF
--- a/firmware/targets/AtlasAtcaLinkAgg/AtlasAtcaLinkAggRd53Rtm_EmuLpGbt/hdl/Application.vhd
+++ b/firmware/targets/AtlasAtcaLinkAgg/AtlasAtcaLinkAggRd53Rtm_EmuLpGbt/hdl/Application.vhd
@@ -132,15 +132,7 @@ architecture mapping of Application is
             retVar(i*6+j) := toSlv((24*i+4*j+3), 7);
          end loop;
       end loop;
-      -- Copy the SFP's uplinks to QSFP[0]
-      for i in 24 to 47 loop
-         retVar(i) := retVar(i-24);
-      end loop;
-      -- Copy the SFP's uplinks to QSFP[1]
-      for i in 48 to 71 loop
-         retVar(i) := retVar(i-48);
-      end loop;
-      for i in 72 to 127 loop
+      for i in 24 to 127 loop
          -- APP.CH[i]  <--- Unused
          retVar(i) := toSlv(127, 7);
       end loop;


### PR DESCRIPTION
connect a single phy channel to multiple App channels could create issues.

For example, the phy channel Rx Delay Tap is controlled by 3 App channels simultaneously, and never working properly in reality.

A simple modification is just to disable the App channel 24 to 127 by default. While the User could change the config through the GUI.